### PR TITLE
BOMを作るPRを作成したが収支が合わないのでボツにした。

### DIFF
--- a/doma-bom/.gitignore
+++ b/doma-bom/.gitignore
@@ -1,0 +1,11 @@
+/.classpath
+/.gradle/
+/.project
+/.settings/
+/bin/
+/build/
+/target/
+/.metadata
+.idea
+out
+.factorypath

--- a/doma-bom/build.gradle.kts
+++ b/doma-bom/build.gradle.kts
@@ -1,0 +1,13 @@
+
+description = "doma-bom"
+
+dependencies {
+    constraints {
+        api(project(":doma-core"))
+        api(project(":doma-kotlin"))
+        api(project(":doma-mock"))
+        api(project(":doma-processor"))
+        api(project(":doma-slf4j"))
+        api(project(":doma-template"))
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,7 @@ pluginManagement {
 
 rootProject.name = "doma"
 
+include("doma-bom")
 include("doma-core")
 include("doma-kotlin")
 include("doma-mock")


### PR DESCRIPTION
implementationとannotationProcessorは名前空間が違うため、platformを共有していない。
つまり、BOMを追加したとしても以下のような宣言方式になる。

### 現状
```
def domaVersion = '3.0.0'
 
dependencies {
    annotationProcessor "org.seasar.doma:doma-processor:${domaVersion}"
    implementation "org.seasar.doma:doma-core:${domaVersion}"
    implementation "org.seasar.doma:doma-slf4j:${domaVersion}"
}
```

### 最悪の状態
```
def domaVersion = '3.0.0'
dependencies {
    implementation platform("org.seasar.doma:doma-bom:${domaVersion}")
    annotationProcessor platform("org.seasar.doma:doma-bom:${domaVersion}")
 
    annotationProcessor "org.seasar.doma:doma-processor"
    implementation "org.seasar.doma:doma-core"
    implementation "org.seasar.doma:doma-slf4j"
}
```

### 少し圧縮した状態
```
def domaVersion = '3.0.0'
dependencies {
    implementation platform("org.seasar.doma:doma-bom:${domaVersion}")
 
    annotationProcessor "org.seasar.doma:doma-processor:${domaVersion}"
    implementation "org.seasar.doma:doma-core"
    implementation "org.seasar.doma:doma-slf4j"
}
```



https://github.com/gradle/gradle/issues/8723
https://stackoverflow.com/questions/70397868/why-doesnt-my-annotationprocessor-configuration-see-the-version-in-my-gradle-pl
https://github.com/gradle/gradle/issues/12519